### PR TITLE
feat: include changed lines in contents endpoint

### DIFF
--- a/app/core/github.py
+++ b/app/core/github.py
@@ -1,3 +1,5 @@
+import base64
+import re
 import httpx
 from typing import Any, Dict, List, Optional
 from app.config import Settings, get_settings
@@ -49,6 +51,45 @@ class GitHubClient:
     async def list_pull_request_files(self, owner: str, repo: str, number: int) -> List[str]:
         items = await self._paginate(f"/repos/{owner}/{repo}/pulls/{number}/files", {"per_page": 100})
         return [i.get("filename", "") for i in items]
+
+    async def get_pull_request_contents(self, owner: str, repo: str, number: int) -> List[Dict[str, Any]]:
+        items = await self._paginate(f"/repos/{owner}/{repo}/pulls/{number}/files", {"per_page": 100})
+        results: List[Dict[str, Any]] = []
+        for item in items:
+            filename = item.get("filename", "")
+            contents_url = item.get("contents_url")
+            patch = item.get("patch") or ""
+            content = ""
+            if contents_url:
+                r = await self._client.get(contents_url)
+                r.raise_for_status()
+                data = r.json()
+                encoded = data.get("content")
+                if encoded:
+                    content = base64.b64decode(encoded).decode()
+            changed = self._parse_patch(patch)
+            results.append({"filename": filename, "content": content, "changedLines": changed})
+        return results
+
+    @staticmethod
+    def _parse_patch(patch: str) -> List[int]:
+        changed: List[int] = []
+        if not patch:
+            return changed
+        line_no = 0
+        for line in patch.splitlines():
+            if line.startswith("@@"):
+                m = re.match(r"@@ -\d+(?:,\d+)? \+(\d+)", line)
+                if m:
+                    line_no = int(m.group(1)) - 1
+            elif line.startswith("+") and not line.startswith("+++"):
+                line_no += 1
+                changed.append(line_no)
+            elif line.startswith("-") and not line.startswith("---"):
+                pass
+            else:
+                line_no += 1
+        return changed
 
 
 # FastAPI dependency factory

--- a/app/model/schemas.py
+++ b/app/model/schemas.py
@@ -13,6 +13,12 @@ class PRItem(BaseModel):
     files: List[str]
 
 
+class FileContent(BaseModel):
+    filename: str
+    content: str
+    changedLines: List[int]
+
+
 class Project(BaseModel):
     ProjectName: str
     ProjectId: str

--- a/app/routes/prs.py
+++ b/app/routes/prs.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query, HTTPException
 from app.core.github import get_github_client, GitHubClient
 from app.services.pr_service import PRService
-from app.model.schemas import PRItem
+from app.model.schemas import PRItem, FileContent
 from app.config import get_settings
 
 router = APIRouter(prefix="/api/prs", tags=["PRs"])
@@ -19,3 +19,16 @@ async def get_prs(
         raise HTTPException(status_code=400, detail="Set GITHUB_TOKEN for higher rate limits.")
     svc = PRService(gh)
     return await svc.list_prs(owner=owner, repos=repo, state=state)
+
+
+@router.get("/{owner}/{repo}/{number}/contents", response_model=List[FileContent])
+async def get_pr_contents(
+    owner: str,
+    repo: str,
+    number: int,
+    gh: GitHubClient = Depends(get_github_client),
+):
+    if not get_settings().github_token:
+        raise HTTPException(status_code=400, detail="Set GITHUB_TOKEN for higher rate limits.")
+    svc = PRService(gh)
+    return await svc.get_pr_contents(owner, repo, number)

--- a/app/services/pr_service.py
+++ b/app/services/pr_service.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List, Dict, Any
 from app.core.github import GitHubClient
-from app.model.schemas import PRItem
+from app.model.schemas import PRItem, FileContent
 from app.utils.time import humanize_from_now
 
 AI_LABELS = { "ai-reviewed", "ai_reviewed", "ai:reviewed" }
@@ -47,3 +47,7 @@ class PRService:
         items = await asyncio.gather(*tasks)
         # Sort by recency if desired (left as-is to preserve input order)
         return items
+
+    async def get_pr_contents(self, owner: str, repo: str, number: int) -> List[FileContent]:
+        data = await self.gh.get_pull_request_contents(owner, repo, number)
+        return [FileContent(**d) for d in data]


### PR DESCRIPTION
## Summary
- add FileContent schema capturing filename, content and changed lines
- expose `/api/prs/{owner}/{repo}/{number}/contents` to return file contents with changed line numbers
- parse GitHub patches to compute changed lines

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1936c5fc0832b990218f02e027d8a